### PR TITLE
switch from deprecated template

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
 			{{- partial "fathom" . -}}
 			{{ end }}
 
-			{{ template "_internal/google_analytics_async.html" . }}
+			{{ template "_internal/google_analytics.html" . }}
 		</div>
 		{{- with .Site.Params.Social -}}
 		<script>feather.replace({
@@ -30,7 +30,7 @@
 		})
 		</script>
 		{{- end }}
-		
+
 		<script src="{{ "/js/main.js" | relURL }}"></script>
 	</body>
 


### PR DESCRIPTION
Looks like the async template doesn't exist anymore: https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410